### PR TITLE
[ORG] RU-AXAV: Rollforward of https://github.com/bazelbuild/bazel/commit/cecb3f1650d…

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
@@ -67,8 +67,18 @@ java_library(
     ],
 )
 
-java_binary(
+sh_binary(
     name = "Desugar",
+    srcs = ["desugar.sh"],
+    data = [":Desugar_java"],
+    visibility = [
+        "//src/test/java/com/google/devtools/build/android/desugar:__pkg__",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+java_binary(
+    name = "Desugar_java",
     main_class = "com.google.devtools.build.android.desugar.Desugar",
     visibility = [
         "//src/test/java/com/google/devtools/build/android/desugar:__pkg__",

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/desugar.sh
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/desugar.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# A wrapper around the desugar binary that sets
+# jdk.internal.lambda.dumpProxyClasses.
+
+# exit on errors and uninitialized variables
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+readonly TMPDIR="$(mktemp -d)"
+trap "rm -rf ${TMPDIR}" EXIT
+$(rlocation io_bazel/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar_java) \
+  "--jvm_flag=-Djdk.internal.lambda.dumpProxyClasses=${TMPDIR}" "$@"


### PR DESCRIPTION
…642dc626d6f418282bd802c29f6d7: Create a wrapper around the desugar binary that sets jdk.internal.lambda.dumpProxyClasses

In JDK11 >11.0.9.1, the platform uses lambdas early enough that the LambdaMetaFactory
class gets loaded by desugar's main is reached, so it doesn't get a chance
to set the dump directory.

The wrapper script let's us upgrade JDK version.

Fixes https://github.com/bazelbuild/bazel/issues/12880

PiperOrigin-RevId: 401933663